### PR TITLE
Fix the incorrect docblock

### DIFF
--- a/src/Traits/Request.php
+++ b/src/Traits/Request.php
@@ -42,9 +42,9 @@ trait Request
     }
 
     /**
-     * Request a create to API.
+     * Request to retrieve a resource in API.
      *
-     * @param array $payload
+     * @param string $payload
      * @return Model
      */
     public function find($payload)


### PR DESCRIPTION
Fixes #33.

Fixed the incorrect docblock that results to an error when using `phpstan`