### PR TITLE
Reintroduce `paymongo.webhook_signature` config

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -44,6 +44,11 @@ return [
         'payment_failed' => env('PAYMONGO_WEBHOOK_SIG_PAYMENT_FAILED', env('PAYMONGO_WEBHOOK_SIG')),
         'source_chargeable' => env('PAYMONGO_WEBHOOK_SIG_SOURCE_CHARGABLE', env('PAYMONGO_WEBHOOK_SIG')),
     ],
+    
+    /**
+     * Webhook signature configuration for backwards compatibility.
+     */
+    'webhook_signature' => env('PAYMONGO_WEBHOOK_SIG'),
 
     /*
      * This is the name of the header where the signature will be added.

--- a/config/config.php
+++ b/config/config.php
@@ -44,7 +44,7 @@ return [
         'payment_failed' => env('PAYMONGO_WEBHOOK_SIG_PAYMENT_FAILED', env('PAYMONGO_WEBHOOK_SIG')),
         'source_chargeable' => env('PAYMONGO_WEBHOOK_SIG_SOURCE_CHARGABLE', env('PAYMONGO_WEBHOOK_SIG')),
     ],
-    
+
     /**
      * Webhook signature configuration for backwards compatibility.
      */


### PR DESCRIPTION
The key is being used in the [middleware](https://github.com/rdaitan-cp/laravel-paymongo/blob/1.x/src/Middlewares/PaymongoValidateSignature.php#L71) but no longer exists in the configuration. This caused existing installations of the library to no longer accept Source Chargeable webhooks.

The problem can be replicated by using the middleware without the event parameter.